### PR TITLE
fixed order of docker command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db    # Windows specific files
 # For example, if you're working with Python:
 __pycache__/ # Python byte code cache
 *.pyc        # Compiled Python files
+.python-version
 
 # Build artifacts and dependencies
 /build/

--- a/propeller/rag/README.md
+++ b/propeller/rag/README.md
@@ -11,7 +11,7 @@ Requires Ollama and Mistral model
 
 Run ollama locally in docker
 ```
-docker run -d -p 11434:11434 ollama/ollama --name ollama_cyverse
+docker run -d -p 11434:11434 --name ollama_cyverse ollama/ollama
 ```
 
 Download mistral model


### PR DESCRIPTION
Found docker wasn't starting for me following readme? Changing order of --name before made it work for me (ubuntu 22 / docker 24.0.7)