### PR TITLE
Update langclient with an endpoint per vectordb

### DIFF
--- a/propeller/langserve/.gitignore
+++ b/propeller/langserve/.gitignore
@@ -1,1 +1,2 @@
+__pycache__
 vectordb/

--- a/propeller/langserve/Dockerfile.langserve
+++ b/propeller/langserve/Dockerfile.langserve
@@ -6,7 +6,6 @@ COPY . .
 ENV HOST=0.0.0.0
 ENV PORT=8000
 ENV VECTORSTORE=/opt/vectorstore
-ENV COLLECTION=cyverse
 ENV OLLAMA_HOST=localhost
 ENV MODEL=mixtral
 
@@ -20,4 +19,4 @@ RUN pip3 install --upgrade pip && \
 
 EXPOSE ${PORT}
 
-ENTRYPOINT ["/bin/bash", "-c", "python3 /opt/langserve/langclient.py ${HOST} ${PORT} ${VECTORSTORE} ${COLLECTION} ${OLLAMA_HOST} ${MODEL}"]
+ENTRYPOINT ["/bin/bash", "-c", "python3 /opt/langserve/langclient.py ${HOST} ${PORT} ${VECTORSTORE} ${OLLAMA_HOST} ${MODEL}"]


### PR DESCRIPTION
This PR will update `langclient` with an endpoint per vectordb, and to return the available vectordbs in a JSON response from the root endpoint.

These changes currently expect separate vector db folders under the `VECTORSTORE` path given on the command line, as was the case before #11.
